### PR TITLE
Add ability to deny tokens that are being reused

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,21 @@ After you've created your Devise user models (which is usually done with a "rail
 
     rails g devise_two_factor MODEL
 
+Then generate the migrations:
+     
+    rails g devise_two_factor:migrations MODEL
+
 Don't forget to migrate:
+
+    rake db:migrate
+
+### Updating
+
+After updating the gem, run to install the latest migrations:
+
+    rails g devise_two_factor:migrations MODEL
+
+And don't forget to migrate:
 
     rake db:migrate
 

--- a/devise_2fa.gemspec
+++ b/devise_2fa.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
+  gem.post_install_message = 'Ensure you run db:migrate'
 
   gem.add_dependency "rails", "~> 5.0"
 

--- a/lib/generators/active_record/devise_two_factor_generator.rb
+++ b/lib/generators/active_record/devise_two_factor_generator.rb
@@ -1,14 +1,10 @@
+# frozen_string_literal: true
+
 require 'rails/generators/active_record'
 
 module ActiveRecord
   module Generators
     class DeviseTwoFactorGenerator < ActiveRecord::Generators::Base
-      source_root File.expand_path('../templates', __FILE__)
-
-      def copy_devise_migration
-        migration_template 'migration.rb', "db/migrate/devise_two_factor_add_to_#{table_name}.rb"
-      end
-
       def inject_field_types
         class_path = if namespaced?
           class_name.to_s.split("::")
@@ -26,6 +22,10 @@ module ActiveRecord
   validates :otp_auth_secret, symmetric_encryption: true
   validates :otp_recovery_secret, symmetric_encryption: true
 RUBY
+      end
+
+      def model_exists?
+        File.exist? "app/models/#{table_name}.rb"
       end
     end
   end

--- a/lib/generators/active_record/templates/add_last_successful_otp_at.rb
+++ b/lib/generators/active_record/templates/add_last_successful_otp_at.rb
@@ -1,0 +1,14 @@
+class DeviseTwoFactorAddLastSuccessfulOtpAtTo<%= table_name.camelize %> < ActiveRecord::Migration[5.0]
+  def self.up
+    change_table :<%= table_name %> do |t|
+      t.datetime :last_successful_otp_at
+    end
+  end
+
+  def self.down
+    change_table :<%= table_name %> do |t|
+      t.remove :last_successful_otp_at
+    end
+  end
+end
+

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,4 +1,4 @@
-class DeviseTwoFactorAddTo<%= table_name.camelize %> < ActiveRecord::Migration
+class DeviseTwoFactorAddTo<%= table_name.camelize %> < ActiveRecord::Migration[5.0]
   def self.up
     change_table :<%= table_name %> do |t|
       t.string    :otp_auth_secret

--- a/lib/generators/devise_two_factor/migrations_generator.rb
+++ b/lib/generators/devise_two_factor/migrations_generator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails/generators/active_record'
+
+module DeviseTwoFactor
+  module Generators # :nodoc:
+    class MigrationsGenerator < ActiveRecord::Generators::Base
+      source_root File.expand_path('../../active_record/templates', __FILE__)
+
+      def copy_devise_migration
+        migration_template 'migration.rb',
+                           "db/migrate/devise_two_factor_add_to_#{table_name}.rb"
+        migration_template 'add_last_successful_otp_at.rb',
+                           "db/migrate/devise_two_factor_add_last_successful_otp_at_to_#{table_name}.rb"
+      end
+    end
+  end
+end

--- a/spec/dummy/config/initializers/devise.rb
+++ b/spec/dummy/config/initializers/devise.rb
@@ -326,4 +326,35 @@ Devise.setup do |config|
   # The name of the token issuer, to be added to the provisioning
   # url. Display will vary based on token application. (defaults to the Rails application class)
   config.otp_issuer = 'dummy'
+
+  # ==> Devise TwoFactor Extension
+  # Configure OTP extension for devise
+
+  # OTP is mandatory, users are going to be asked to
+  # enroll OTP the next time they sign in, before they can successfully complete the session establishment.
+  # This is the global value, can also be set on each user.
+  #config.otp_mandatory = false
+
+  # Drift: a window which provides allowance for drift between a user's token device clock
+  # (and therefore their OTP tokens) and the authentication server's clock.
+  # Expressed in minutes centered at the current time. (Note: it's a number, *NOT* 3.minutes )
+  #config.otp_drift_window = 3
+
+  # Users that have logged in longer than this time ago, are going to be asked their password
+  # (and an OTP challenge, if enabled) before they can see or change their otp informations.
+  #config.otp_credentials_refresh = 15.minutes
+
+  # Users are given a list of one-time recovery tokens, for emergency access
+  # set to false to disable giving recovery tokens.
+  #config.otp_recovery_tokens = 10
+
+  # The user is allowed to set his browser as "trusted", no more OTP challenges will be
+  # asked for that browser, for a limited time.
+  # set to false to disable setting the browser as trusted
+  #config.otp_trust_persistence = 1.month
+
+  # The name of the token issuer, to be added to the provisioning
+  # url. Display will vary based on token application. (defaults to the Rails application class)
+  #config.otp_issuer = 'my_application'
+
 end

--- a/spec/dummy/db/migrate/20190322183459_devise_two_factor_add_last_successful_otp_at_to_users.rb
+++ b/spec/dummy/db/migrate/20190322183459_devise_two_factor_add_last_successful_otp_at_to_users.rb
@@ -1,0 +1,14 @@
+class DeviseTwoFactorAddLastSuccessfulOtpAtToUsers < ActiveRecord::Migration[5.0]
+  def self.up
+    change_table :users do |t|
+      t.datetime :last_successful_otp_at
+    end
+  end
+
+  def self.down
+    change_table :users do |t|
+      t.remove :last_successful_otp_at
+    end
+  end
+end
+

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_12_222952) do
+ActiveRecord::Schema.define(version: 2019_03_22_185449) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_03_12_222952) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "last_successful_otp_at"
     t.string "otp_auth_secret"
     t.string "otp_recovery_secret"
     t.boolean "otp_enabled", default: false, null: false

--- a/spec/system/refresh_spec.rb
+++ b/spec/system/refresh_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'Refresh' do
   end
 
   it 'user should be finally be able to access their settings, if they provide both a password and a valid OTP token' do
+    User.otp_drift_window = 1
     enable_otp_and_sign_in_with_otp user
 
     sleep(2)

--- a/spec/system/token_spec.rb
+++ b/spec/system/token_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Tokens' do
     expect(current_path).to eq(root_path)
   end
 
-  xit 'cannot be reused' do
+  it 'cannot be reused' do
     enable_otp_and_sign_in user
 
     prev_token = ROTP::TOTP.new(user.otp_auth_secret).at(Time.now)

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe 'Users' do
         expect(current_path).to eq(root_path)
       end
 
+      it 'saves the last_success_otp_at when the user successfully otps upon signing in' do
+        enable_otp_and_sign_in user
+        fill_in 'user_token', with: ROTP::TOTP.new(user.otp_auth_secret).at(Time.now)
+        time = Time.now
+        click_button 'Submit Token'
+
+        user.reload
+        expect(user.last_successful_otp_at).to be_within(2.seconds).of(Time.now)
+      end
+
       it 'fails with an incorrect code' do
         enable_otp_and_sign_in user
         fill_in 'user_token', with: '123456'


### PR DESCRIPTION
This adds the ability to deny tokens that are being reused. It adds `last_successful_otp_at` to the model implementing devise-2fa. It also breaks apart installation into two steps:

Install before: 

```
$ rails g devise_two_factor:install                                                                            
      insert  config/initializers/devise.rb                                                                                                   
      create  config/locales/devise.two_factor.en.yml                                                                                         
$ rails g devise_two_factor User                                                                               
      insert  app/models/user.rb                                                                                                              
      invoke  active_record                                                                                                                   
      create  db/migrate/20190515184941_devise_two_factor_add_to_users.rb
```

Install now that we have broken up `rails g devise_two_factor User` into two steps, and added the `last_successful_otp_at` migration:

```
$ rails g devise_two_factor:install
      insert  config/initializers/devise.rb
      create  config/locales/devise.two_factor.en.yml
$ rails g devise_two_factor User 
      insert  app/models/user.rb
      invoke  active_record
$ rails g devise_two_factor:migrations User 
      create  db/migrate/20190515185359_devise_two_factor_add_to_users.rb
      create  db/migrate/20190515185360_devise_two_factor_add_last_successful_otp_at_to_users.rb
```

This was done to ease upgrading the gem and adding `last_successful_otp_at`. You can run the last command to add the migration.