### PR TITLE
 Fix inaccurate otp_drift_window value

### DIFF
--- a/devise_2fa.gemspec
+++ b/devise_2fa.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rails", ">= 4.1", "< 6.1"
 
   gem.add_runtime_dependency 'devise', '~> 4.0'
-  gem.add_runtime_dependency 'rotp', '~> 4.1'
+  gem.add_runtime_dependency 'rotp', '~> 5.1'
   gem.add_runtime_dependency 'rqrcode', '~> 0.10.1'
   gem.add_runtime_dependency 'symmetric-encryption', '~> 4.3.0'
 

--- a/lib/devise_two_factorable/models/two_factorable.rb
+++ b/lib/devise_two_factorable/models/two_factorable.rb
@@ -117,10 +117,15 @@ module Devise::Models
     private
 
     def validate_otp_token_with_drift(token)
-      # should be centered around saved drift
-      (-self.class.otp_drift_window..self.class.otp_drift_window).any? do |drift|
-        time_based_otp.verify(token, drift_behind: (0.5 * drift), at: Time.now + (0.5 * drift))
-      end
+      time_based_otp.verify(
+        token,
+        drift_behind: drift.minutes.seconds,
+        at: Time.now + drift.minutes.seconds / 2
+      )
+    end
+
+    def drift
+      self.class.otp_drift_window
     end
 
     def generate_otp_persistence_seed

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe User, type: :model do
-  subject (:user) { User.new(email: 'mb@geemail.com', password: 'iwantabigmac1') }
+  subject(:user) { User.create(email: 'mb@geemail.com', password: 'iwantabigmac1') }
   it 'is valid' do
     expect(user).to be_valid
   end
@@ -23,10 +23,55 @@ RSpec.describe User, type: :model do
     end
 
     describe '#password' do
-      subject(:user) { User.new(email: 'mb@geemail.com')}
+      subject(:user) { User.new(email: 'mb@geemail.com') }
 
       it 'is required' do
         expect(user).to be_invalid
+      end
+    end
+  end
+
+  describe '#validate_otp_token' do
+    context 'when otp_drift_window is 3 minutes (default)' do
+      let(:user_rotp) { ROTP::TOTP.new(user.otp_auth_secret) }
+      let(:control_time) { Time.now }
+      let(:token_time) { control_time }
+
+      before do
+        Devise.otp_drift_window = 3
+        allow(Time).to receive(:now).and_return(control_time)
+      end
+
+      context "when token's time is 2 minutes before current time" do
+        let(:token_time) { control_time - 2.minutes }
+
+        it do
+          expect(user.validate_otp_token(user_rotp.at(token_time))).to be_falsey
+        end
+      end
+
+      context "when token's time is 1 minute before current time" do
+        let(:token_time) { control_time - 1.minute }
+
+        it do
+          expect(user.validate_otp_token(user_rotp.at(token_time))).to be_truthy
+        end
+      end
+
+      context "when token's time is 1 minute after current time" do
+        let(:token_time) { control_time + 1.minute }
+
+        it do
+          expect(user.validate_otp_token(user_rotp.at(token_time))).to be_truthy
+        end
+      end
+
+      context "when token's time is 2 minutes after current time" do
+        let(:token_time) { control_time + 2.minute }
+
+        it do
+          expect(user.validate_otp_token(user_rotp.at(token_time))).to be_falsey
+        end
       end
     end
   end

--- a/spec/system/token_spec.rb
+++ b/spec/system/token_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Tokens' do
-  subject (:user) { User.create(email: 'mb@geemail.com', password: 'iwantabigmac1') }
+  subject(:user) { User.create(email: 'mb@geemail.com', password: 'iwantabigmac1') }
 
   it 'can be disabled by a user after successfully enabling' do
     enable_otp_and_sign_in user


### PR DESCRIPTION
drift_behind: and at: both accept seconds
This also addresses a math issue to accept forward as well as backwards
In example of the default config, the code now accepts 3 minutes
"behind" the time we're checking for, and check for 1.5 minutes "ahead"
the time we're checking for, resulting in an even split between before
and after Time.now

This also removes the need to enumerate through the otp_drift_window,
which should be marginally faster the validate otp tokens

Includes specs to prove functionality