### PR TITLE
Updates model encryption field designation for SymmetricEncryption

### DIFF
--- a/devise_2fa.gemspec
+++ b/devise_2fa.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rotp', '~> 5.1'
   gem.add_runtime_dependency 'rqrcode', '~> 0.10.1'
   gem.add_runtime_dependency 'symmetric-encryption', '~> 4.3.0'
+  gem.requirements << 'SymmetricEncryption must be configured prior to using this gem.'
 
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'capybara'

--- a/lib/generators/active_record/devise_two_factor_generator.rb
+++ b/lib/generators/active_record/devise_two_factor_generator.rb
@@ -23,8 +23,6 @@ module ActiveRecord
 <<RUBY
   attribute :otp_auth_secret, :encrypted
   attribute :otp_recovery_secret, :encrypted
-  validates :otp_auth_secret, symmetric_encryption: true, if: proc { |o| o.otp_enabled? }
-  validates :otp_recovery_secret, symmetric_encryption: true, if: proc { |o| o.otp_enabled? }
 RUBY
       end
 

--- a/lib/generators/active_record/devise_two_factor_generator.rb
+++ b/lib/generators/active_record/devise_two_factor_generator.rb
@@ -21,10 +21,10 @@ module ActiveRecord
 
       def content
 <<RUBY
-  attr_encrypted :otp_auth_secret
-  attr_encrypted :otp_recovery_secret
-  validates :otp_auth_secret, symmetric_encryption: true
-  validates :otp_recovery_secret, symmetric_encryption: true
+  attribute :otp_auth_secret, :encrypted
+  attribute :otp_recovery_secret, :encrypted
+  validates :otp_auth_secret, symmetric_encryption: true, if: proc { |o| o.otp_enabled? }
+  validates :otp_recovery_secret, symmetric_encryption: true, if: proc { |o| o.otp_enabled? }
 RUBY
       end
 


### PR DESCRIPTION
When Symmetric Encryption was updated in a past release, the field designations in the generator were not altered to reflect the upgrade's new expected format.  This PR should fix the NoMethodError: undefined method `attr_encrypted' error as reported by @richardonrails in #21.