### PR TITLE
Make encrypting secrets with symmetric-encryption optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,6 @@ build_config: &build_config
         key: v1-dependencies-{{ checksum "devise_2fa.gemspec" }}-{{ checksum "Appraisals" }}
 
     - run:
-        name: Setup Symmetric Encryption Config
-        command: |
-          cd spec/dummy/
-          symmetric-encryption -g
-
-    - run:
         name: Run Tests
         command: |
           mkdir /tmp/test-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- *Possibly Breaking*: Remove assumption of using symmetric-encryption gem and replace with optional instructions for how to encrypt secrets. For existing applications, you'll likely need to add `gem 'symmetric-encryption'` to your Gemfile if it's not already there.
 
 ## [0.4.1] - 2019-10-31
 ### Changed

--- a/devise_2fa.gemspec
+++ b/devise_2fa.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'devise', '~> 4.6'
   gem.add_runtime_dependency 'rotp', '~> 5.1'
   gem.add_runtime_dependency 'rqrcode', '~> 0.10.1'
-  gem.add_runtime_dependency 'symmetric-encryption', '~> 4.3.0'
 
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'capybara'

--- a/lib/generators/active_record/devise_two_factor_generator.rb
+++ b/lib/generators/active_record/devise_two_factor_generator.rb
@@ -8,35 +8,6 @@ module ActiveRecord
       def copy_devise_migration
         migration_template 'migration.rb', "db/migrate/devise_two_factor_add_to_#{table_name}.rb"
       end
-
-      def inject_field_types
-        class_path = if namespaced?
-          class_name.to_s.split("::")
-        else
-          [class_name]
-        end
-
-        inject_into_class(model_path, class_path.last, content) if model_exists?
-      end
-
-      def content
-<<RUBY
-  attr_encrypted :otp_auth_secret
-  attr_encrypted :otp_recovery_secret
-  validates :otp_auth_secret, symmetric_encryption: true
-  validates :otp_recovery_secret, symmetric_encryption: true
-RUBY
-      end
-
-      private
-
-      def model_exists?
-        File.exist?(File.join(destination_root, model_path))
-      end
-
-      def model_path
-        @model_path ||= File.join("app", "models", "#{file_path}.rb")
-      end
     end
   end
 end

--- a/lib/generators/mongoid/devise_two_factor_generator.rb
+++ b/lib/generators/mongoid/devise_two_factor_generator.rb
@@ -13,8 +13,8 @@ module Mongoid
       def migration_data
 <<RUBY
   # Devise TwoFactor
-  field :encrypted_otp_auth_secret,       type: String, encrypted: true
-  field :encrypted_otp_recovery_secret,   type: String, encrypted: true
+  field :otp_auth_secret,                 type: String
+  field :otp_recovery_secret,             type: String
   field :otp_enabled,                     type: Boolean, default: false
   field :otp_mandatory,                   type: Boolean, default: false
   field :otp_enabled_on,                  type: DateTime

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'symmetric_encryption'
-
 if defined?(ActiveRecord)
   class User < ApplicationRecord
     devise :two_factorable, :database_authenticatable, :registerable,
@@ -11,8 +9,8 @@ else
   require 'mongoid'
   class User
     include Mongoid::Document
-    field :encrypted_otp_auth_secret,       type: String, encrypted: true
-    field :encrypted_otp_recovery_secret,   type: String, encrypted: true
+    field :otp_auth_secret,                 type: String
+    field :otp_recovery_secret,             type: String
     field :otp_enabled,                     type: Boolean, default: false
     field :otp_mandatory,                   type: Boolean, default: false
     field :otp_enabled_on,                  type: DateTime


### PR DESCRIPTION
Previously it was assumed you were using symmetric-encryption to encrypt
the secrets in the database for extra security, however the gem itself
wasn't actually required, leading to trouble setting things up for the
first time.

Now encryption is treated as an optional added layer of security with
instructions on how to accomplish it. This should also open the door to
using alternate encryption strategies.

This should fix #21.