### PR TITLE
Use update! instead of update_attributes!

### DIFF
--- a/devise_2fa.gemspec
+++ b/devise_2fa.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency "rails", ">= 4.1", "< 7.0"
+  gem.add_dependency "rails", ">= 4.1", "<= 7.0"
 
   gem.add_runtime_dependency 'devise', '~> 4.6'
   gem.add_runtime_dependency 'rotp', '~> 5.1'

--- a/devise_2fa.gemspec
+++ b/devise_2fa.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency "rails", ">= 4.1", "< 6.2"
+  gem.add_dependency "rails", ">= 4.1", "< 7.0"
 
   gem.add_runtime_dependency 'devise', '~> 4.6'
   gem.add_runtime_dependency 'rotp', '~> 5.1'

--- a/devise_2fa.gemspec
+++ b/devise_2fa.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency "rails", ">= 4.1", "<= 7.0"
+  gem.add_dependency "rails", ">= 4.1"
 
   gem.add_runtime_dependency 'devise', '~> 4.6'
   gem.add_runtime_dependency 'rotp', '~> 5.1'

--- a/devise_2fa.gemspec
+++ b/devise_2fa.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'devise', '~> 4.6'
   gem.add_runtime_dependency 'rotp', '~> 5.1'
   gem.add_runtime_dependency 'rqrcode', '~> 0.10.1'
-  gem.add_runtime_dependency 'symmetric-encryption', '~> 4.3.0'
+  gem.add_runtime_dependency 'symmetric-encryption', '>= 4.3.0'
 
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'capybara'

--- a/devise_2fa.gemspec
+++ b/devise_2fa.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency "rails", ">= 4.1", "< 6.1"
+  gem.add_dependency "rails", ">= 4.1", "< 6.2"
 
   gem.add_runtime_dependency 'devise', '~> 4.6'
   gem.add_runtime_dependency 'rotp', '~> 5.1'

--- a/lib/devise-2fa.rb
+++ b/lib/devise-2fa.rb
@@ -63,7 +63,7 @@ module Devise
   # the name of the token issuer
   #
   mattr_accessor :otp_issuer
-  @@otp_issuer = Rails.application.class.parent_name
+  @@otp_issuer = Rails.application.class.module_parent_name
 
   module TwoFactor
   end

--- a/lib/devise_two_factorable/models/two_factorable.rb
+++ b/lib/devise_two_factorable/models/two_factorable.rb
@@ -24,7 +24,7 @@ module Devise::Models
     end
 
     def time_based_otp
-      @time_based_otp ||= ROTP::TOTP.new(otp_auth_secret, issuer: (self.class.otp_issuer || Rails.application.class.parent_name).to_s)
+      @time_based_otp ||= ROTP::TOTP.new(otp_auth_secret, issuer: (self.class.otp_issuer || Rails.application.class.module_parent_name).to_s)
     end
 
     def recovery_otp

--- a/lib/devise_two_factorable/models/two_factorable.rb
+++ b/lib/devise_two_factorable/models/two_factorable.rb
@@ -44,7 +44,7 @@ module Devise::Models
       @recovery_otp = nil
       generate_otp_auth_secret
       reset_otp_persistence
-      update_attributes!(otp_enabled: false,
+      update!(otp_enabled: false,
                          otp_session_challenge: nil,
                          otp_challenge_expires: nil,
                          otp_recovery_counter: 0)
@@ -67,15 +67,15 @@ module Devise::Models
     def enable_otp!
       reset_otp_credentials! if otp_persistence_seed.nil?
 
-      update_attributes!(otp_enabled: true, otp_enabled_on: Time.now)
+      update!(otp_enabled: true, otp_enabled_on: Time.now)
     end
 
     def disable_otp!
-      update_attributes!(otp_enabled: false, otp_enabled_on: nil)
+      update!(otp_enabled: false, otp_enabled_on: nil)
     end
 
     def generate_otp_challenge!(expires = nil)
-      update_attributes!(otp_session_challenge: SecureRandom.hex,
+      update!(otp_session_challenge: SecureRandom.hex,
                          otp_challenge_expires: DateTime.now + (expires || self.class.otp_authentication_timeout))
       otp_session_challenge
     end


### PR DESCRIPTION
Rails 6+ will complain about the usage of `update_attributes!`. This updates the code to use `update!`

I.e.

```
ActiveSupport::DeprecationException: DEPRECATION WARNING: update_attributes! is deprecated and will be removed from Rails 6.1 (please, use update! instead) (called from reset_otp_credentials at /home/vagrant/.bundle/ruby/2
.6.0/devise-2fa-815fb0a20df3/lib/devise_two_factorable/models/two_factorable.rb:47)
```